### PR TITLE
Fix build on macOS/arm64 (M1)

### DIFF
--- a/Formula/verible.rb
+++ b/Formula/verible.rb
@@ -30,7 +30,6 @@ class Verible < Formula
     bazel_args = %W[
       --jobs=#{ENV.make_jobs}
       --compilation_mode=opt
-      --copt=-march=native
     ]
     system "bazel", "build", *bazel_args, "//..."
     system "bazel", "test", *bazel_args, "//..."


### PR DESCRIPTION
Apple clang does not currently support `march=native` on arm64/M1. If there's a noticeable performance difference on other platforms, I can make avoiding the flag conditional to `Hardware::CPU.arm?`.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR